### PR TITLE
Allow custom url predecessor path segments

### DIFF
--- a/spec/3.0/pygmy.js
+++ b/spec/3.0/pygmy.js
@@ -14,7 +14,10 @@ describe("pygmy3_0", function() {
 
 			expect(pygmy3_0.worksWithPage()).toBe(false);
 		});
-
+		it('return true for an angular Octopus app with custom segment', function() {
+			spyOn(commonpygmy, 'location').and.returnValue({ pathname: 'anyurl/app' });
+			expect(pygmy3_0.worksWithPage()).toBe(false);
+		})
 		it("returns false for an angular Octopus app with 2.0 structure", function() {
 			spyOn(commonpygmy, 'location').and.returnValue({ pathname: '/app' });
 			spyOn(commonpygmy, 'document').and.returnValue({ 

--- a/src/3.0/pygmy.js
+++ b/src/3.0/pygmy.js
@@ -6,7 +6,7 @@ var pygmy3_0 = (function() {
 		console.debug("   path: " + commonpygmy.location().pathname);
 		console.debug("   title:" + commonpygmy.document().title);
 
-		if (commonpygmy.location().pathname.indexOf('/app') < 0) return false;
+		if (!commonpygmy.location().pathname.endsWith('/app')) return false;
 		if (commonpygmy.document().title.indexOf("Octopus Deploy") < 0) return false;
 		if (!commonpygmy.document().getElementById(contentElementId)) return false;
 


### PR DESCRIPTION
This allows blue fins to work on sites not hosted on default path