### PR TITLE
Fix environment filter in Octopus Deploy 3.3+

### DIFF
--- a/src/3.0/environment-filter.js
+++ b/src/3.0/environment-filter.js
@@ -31,7 +31,7 @@ pygmy3_0.environmentFilter = (function () {
 
 	function add33TargetToCache(node) {
 		var targets = node.getElementsByTagName("LI");
-		targets.forEach(addTargetToCache);
+		_.each(targets, addTargetToCache);
 	}
 	
 	function addTargetToCache(node) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Bluefin",
   "description": "Eases the management of large installations of targets and projects in Octopus Deploy",
-  "version": "1.52.16",
+  "version": "1.52.17",
   "author": "David Roberts (@davidroberts63), Matt Richardson (@squire_matt)",
   "homepage_url": "http://bluefin.teapotcoder.com",
   "content_scripts": [


### PR DESCRIPTION
The environment filter wasn't working in my install of 3.3.14 and a work installation of 3.4.3.

Turns out the return of `getElementsByTagName` is a `HTMLCollection`. Apparently that doesn't have the `forEach` function as on arrays. So just using **underscore.js** to do it.

Works now though.
