### PR TITLE
Fix filters not showing right after page reload

### DIFF
--- a/src/3.0/environment-collapser.js
+++ b/src/3.0/environment-collapser.js
@@ -25,7 +25,6 @@ pygmy3_0.environmentCollapser = (function() {
 		item.value = id;
 		item.innerHTML = name;
 		
-		chooser = document.getElementById(chooserId);
 		chooser.appendChild(item);
 	}
 
@@ -61,6 +60,7 @@ pygmy3_0.environmentCollapser = (function() {
 			
 			if (node.parentNode && node.parentNode.tagName == 'DIV' && node.getAttribute("ng-repeat") == "environment in environments") {
 				console.debug("Found an inserted environment");
+				ensureChooserExists();
 				addGroupToChooser(node);
 			}
 
@@ -71,6 +71,23 @@ pygmy3_0.environmentCollapser = (function() {
 				commonpygmy.addFilterInput(filterInput, node.parentNode);
 			}
 		}
+	}
+
+	function ensureChooserExists()
+	{
+		if (chooser == null)
+		{
+			console.debug("Adding the environment chooser. Due to hard refresh of page");
+			var breadcrumb = getPageBreadcrumb("Environments");
+			var filterInput = createChooser();
+			commonpygmy.addFilterInput(filterInput, breadcrumb.parentNode);
+		}
+	}
+
+	function getPageBreadcrumb(innerText)
+	{
+		var breadcrumbs = document.querySelectorAll("ul.breadcrumb");
+		return _.find(breadcrumbs, function(crumb) { return crumb.innerText.trim() == innerText; });
 	}
 
 	// Copy and pasted from dashboard collapser. Refactor to common method?


### PR DESCRIPTION
**Review in process: Not ready for merge yet**

When the user reloads the page (F5|Refresh|....) the extension doesn't get loaded in time to catch the `ul.breadcrumbs` node being inserted. This results in the dropdowns not being created, so no environment collapsing. It's fine once they click to different parts of the app.

This catches that case and adds the chooser (<select>) just before an option would be added.
