### PR TITLE
Fix release deployment process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": "google",
+    "rules": {
+        "require-jsdoc": "off",
+        "no-var": "off",
+        "max-len": "off"
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     "rules": {
         "require-jsdoc": "off",
         "no-var": "off",
-        "max-len": "off"
+        "max-len": "off",
+        "prefer-spread": "off"
     }
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": true
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Bluefin",
   "version": "1.0.0",
-  "license": "Apache-2.0",
+  "license": "Apache 2.0",
   "description": "Extension for Octopus Deploy",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,6 @@
     "url": "https://github.com/davidroberts63/OctoPygmy.git"
   },
   "author": "davidroberts63",
-  "license": "Apache 2.0",
   "readmeFilename": "README.md",
   "gitHead": "9f47bf95f8e1cf3ca9985dcced309a83bb5302c0",
   "dependencies": {
@@ -20,5 +19,9 @@
     "saucelabs": "^1.2.0",
     "selenium-webdriver": "2.47.0",
     "jasmine-node": "1.14.5"
+  },
+  "devDependencies": {
+    "eslint": "^4.7.2",
+    "eslint-config-google": "^0.9.1"
   }
 }

--- a/src/3.0/view-release-deployment-process.js
+++ b/src/3.0/view-release-deployment-process.js
@@ -1,206 +1,222 @@
 pygmy3_0.viewReleaseDeploymentProcess = (function() {
-	var octopusVersion;
+  var octopusVersion;
 
-	function receiveMessage(response) {
-        if (response.message == 'get-template-response' && response.properties.templateName == 'show-release-deployment-plan.html') {
-            console.debug("  - got template 'show-release-deployment-plan.html'");
-			console.debug("  - adding handler");
-	        var showDeploymentProcessHandlerScript = document.createElement("script");
-	        showDeploymentProcessHandlerScript.id = 'bluefin-showreleasedeploymentprocess-handler';
-	        showDeploymentProcessHandlerScript.type = 'text/javascript';
-	        var functionAsText = angularShowModalDialog.toString()
-            if (commonpygmy.isNewerVersionThan(pygmy3_0.viewReleaseDeploymentProcess.octopusVersion, "3.4.0")) {
-                functionAsText = functionAsText.replace(/\$modal/g, "$uibModal");
+  function receiveMessage(response) {
+    if (response.message == 'get-template-response' && response.properties.templateName == 'show-release-deployment-plan.html') {
+      console.debug('  - got template \'show-release-deployment-plan.html\'');
+      console.debug('  - adding handler');
+      var showDeploymentProcessHandlerScript = document.createElement('script');
+      showDeploymentProcessHandlerScript.id = 'bluefin-showreleasedeploymentprocess-handler';
+      showDeploymentProcessHandlerScript.type = 'text/javascript';
+      var functionAsText = angularShowModalDialog.toString();
+      if (commonpygmy.isNewerVersionThan(pygmy3_0.viewReleaseDeploymentProcess.octopusVersion, '3.4.0')) {
+        functionAsText = functionAsText.replace(/\$modal/g, '$uibModal');
+      }
+      if (commonpygmy.isNewerVersionThan(pygmy3_0.viewReleaseDeploymentProcess.octopusVersion, '3.8.4')) {
+        functionAsText = functionAsText.replace(/\$routeParams/g, '$stateParams');
+      }
+      functionAsText = functionAsText.replace('#{template}', response.properties.template);
+      showDeploymentProcessHandlerScript.text = functionAsText.slice(functionAsText.indexOf('{') + 1, functionAsText.lastIndexOf('}'));
+      document.body.appendChild(showDeploymentProcessHandlerScript);
+    }
+  }
+
+  function angularShowModalDialog(sendMessageHandler) {
+    var button = document.getElementById('bluefin-showreleasedeploymentprocess-button');
+    button.onClick = button.onclick = function() {
+      var analyticsHandler = document.getElementById('bluefin-showreleasedeploymentprocess-analytics-handler');
+      analyticsHandler.click();
+
+      var element = angular.element('#content-wrapper');
+      var modal = element.injector().get('$modal');
+      modal.open({
+        backdrop: 'static',
+        keyboard: !0,
+        size: 'md',
+        template: '#{template}',
+        controller: function($scope, $routeParams, busy, pageTitle, octopusRepository, pluginRegistry, octoDialog, $modal, $location, unsavedChanges, $modalInstance) {
+          var isLoading = $scope.isLoading = busy.create();
+          $scope.project = null;
+          $scope.close = function() {
+            $modalInstance.close();
+          };
+          $scope.actionClass = function(action) {
+            return action.ActionType.replace('.', '').toLowerCase();
+          },
+            $scope.canHaveChildren = function(step) {
+              var action = pluginRegistry.getDeploymentAction(step.Actions[0].ActionType);
+              return action.canHaveChildren;
+            };
+
+          $scope.releaseVersion = $routeParams.version;
+          var projectId = $routeParams.id || $routeParams.projectId;
+          var version = $routeParams.version;
+          var getTags = function(allOptions, selectedOptions) {
+            if (0 === allOptions.length) {
+              return '';
             }
-            if (commonpygmy.isNewerVersionThan(pygmy3_0.viewReleaseDeploymentProcess.octopusVersion, "3.8.4")) {
-                functionAsText = functionAsText.replace(/\$routeParams/g, "$stateParams");
-            }
-            functionAsText = functionAsText.replace("#{template}", response.properties.template);
-	        showDeploymentProcessHandlerScript.text = functionAsText.slice(functionAsText.indexOf("{") + 1, functionAsText.lastIndexOf("}"));
-	        document.body.appendChild(showDeploymentProcessHandlerScript);
-        }
-	}
+            var result = [];
+            return _.each(selectedOptions, function(e) {
+              allOptions.indexOf(e.Id) >= 0 && result.push(e.Name);
+            }),
+              result.join(',');
+          };
 
-    function angularShowModalDialog(sendMessageHandler) {
-    	var button = document.getElementById('bluefin-showreleasedeploymentprocess-button'); 
-    	button.onClick = button.onclick = function() { 
-            var analyticsHandler = document.getElementById('bluefin-showreleasedeploymentprocess-analytics-handler');
-            analyticsHandler.click();
-
-            var element = angular.element("#content-wrapper");
-            var modal = element.injector().get('$modal');
-			var modalInstance = modal.open({
-                backdrop: "static",
-                keyboard: !0,
-                size: 'md',
-                template: '#{template}',
-                controller: function ($scope, $routeParams, busy, pageTitle, octopusRepository, pluginRegistry, octoDialog, $modal, $location, unsavedChanges, $modalInstance) {
-			        var isLoading = $scope.isLoading = busy.create();
-			        var isSaving = $scope.isSaving = busy.create();
-			        $scope.project = null;
-			        $scope.close = function () { $modalInstance.close(); };
-			        $scope.actionClass = function(action) {
-			            return action.ActionType.replace(".", "").toLowerCase()
-			        },
-			        $scope.canHaveChildren = function(step) {
-			            var action = pluginRegistry.getDeploymentAction(step.Actions[0].ActionType);
-			            return action.canHaveChildren
-			        };
-
-			        $scope.releaseVersion = $routeParams.version;
-			        var projectId = $routeParams.id || $routeParams.projectId;
-			        var version = $routeParams.version;
-			        var getTags = function(allOptions, selectedOptions) {
-			            if (0 === allOptions.length)
-			                return "";
-			            var result = [];
-			            return _.each(selectedOptions, function(e) {
-			                allOptions.indexOf(e.Id) >= 0 && result.push(e.Name)
-			            }),
-			            result.join(",")
-			        };
-
-					//mock out channels for pre-3.2
-					var getChannels = octopusRepository.Projects.getChannels || function (project) {
-						return Octopus.Client.PromiseWrapper(function(resolve, reject) {
-							resolve(null);
-						});
-					};
-
-                    function channelMatches(release, action) {
-                        if (!release.ChannelId || !action.Channels)
-                            return true;
-                        if (action.Channels.length == 0)
-                            return true;
-                        return _.indexOf(action.Channels, release.ChannelId) > -1;
-                    }
-
-			        isLoading.promise(octopusRepository.Projects.get(projectId).then(function(project) {
-			            isLoading.promise(octopusRepository.Lifecycles.get(project.LifecycleId).then(function(lifecycleDefinition) {
-			                isLoading.promise(octopusRepository.Lifecycles.preview(lifecycleDefinition).then(function(lifecycle) {
-			                    isLoading.promise(octopusRepository.Environments.all().then(function(environments) {
-			                        isLoading.promise(getChannels(project).then(function(channels) {
-			                            isLoading.promise(octopusRepository.Projects.getReleaseByVersion(project, version).then(function(release) {
-			                            	isLoading.promise(octopusRepository.DeploymentProcesses.get(release.ProjectDeploymentProcessSnapshotId).then(function(deploymentProcess) {
-			                            		var wasDeployedToChannel = release.ChannelId && release.ChannelId.length > 0 && channels && channels.Items.length > 1;
-			                            		return $scope.project = project,
-					                                $scope.lifecycle = lifecycle,
-					                                $scope.environments = environments,
-					                                $scope.wasDeployedToChannel = wasDeployedToChannel,
-					                                $scope.channelName = wasDeployedToChannel ? _.filter(channels.Items, function(c) { return c.Id == release.ChannelId })[0].Name : null,
-					                                $scope.channels = channels,
-					                                $scope.deploymentProcess = deploymentProcess,
-					                                $scope.builtInFeedPackageActions = _.filter(_.flatten(_.map(deploymentProcess.Steps, function(s) {
-					                                    return s.Actions
-					                                })), function(a) {
-					                                    return "feeds-builtin" === a.Properties["Octopus.Action.Package.NuGetFeedId"]
-					                                }),
-					                                _.each(deploymentProcess.Steps, function(s) {
-					                                    _.each(s.Actions, function(a) {
-					                                    	a.channelMatches = channelMatches(release, a);
-					                                        a.environments = getTags(a.Environments, environments);
-					                                        if (a.channels)
-					                                        	a.channels = getTags(a.Channels, channels.Items)
-					                                    })
-					                                    s.channelMatches = _.any(s.Actions, function(a) { return a.channelMatches;});
-					                                })
-			                            	}))
-			                            }))
-			                        }))
-			                    }))
-			                }))
-			            }))
-			        }));
-			    },
-                dialogClass: "modal"
+          // mock out channels for pre-3.2
+          var getChannels = octopusRepository.Projects.getChannels || function(project) {
+            return Octopus.Client.PromiseWrapper(function(resolve, reject) {
+              resolve(null);
             });
-		}
-    }
+          };
 
-    function addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler) {
-        if (document.getElementById('bluefin-showreleasedeploymentprocess-button'))
-    		return;
+          function channelMatches(release, action) {
+            if (!release.ChannelId || !action.Channels) {
+              return true;
+            }
+            if (action.Channels.length == 0) {
+              return true;
+            }
+            return _.indexOf(action.Channels, release.ChannelId) > -1;
+          }
 
-        console.log("Loading Bluefin feature 'show release deployment process'");
+          isLoading.promise(octopusRepository.Projects.get(projectId).then(function(project) {
+            isLoading.promise(octopusRepository.Lifecycles.get(project.LifecycleId).then(function(lifecycleDefinition) {
+              isLoading.promise(octopusRepository.Lifecycles.preview(lifecycleDefinition).then(function(lifecycle) {
+                isLoading.promise(octopusRepository.Environments.all().then(function(environments) {
+                  isLoading.promise(getChannels(project).then(function(channels) {
+                    isLoading.promise(octopusRepository.Projects.getReleaseByVersion(project, version).then(function(release) {
+                      isLoading.promise(octopusRepository.DeploymentProcesses.get(release.ProjectDeploymentProcessSnapshotId).then(function(deploymentProcess) {
+                        var wasDeployedToChannel = release.ChannelId && release.ChannelId.length > 0 && channels && channels.Items.length > 1;
+                        var getActionFromStep = function(s) {
+                          return s.Actions;
+                        };
+                        var isBuiltInFeedAction = function(a) {
+                          return 'feeds-builtin' === a.Properties['Octopus.Action.Package.NuGetFeedId'];
+                        };
 
-    	var headings = document.querySelectorAll('h3');
-    	var variablesHeading;
-    	for(var i=0; i < headings.length; i++ ) {
-    		if (headings[i].innerText === 'Variables') {
-    			variablesHeading = headings[i];
-    		}
-    	}
-		var variablesNote = variablesHeading.nextSibling.nextSibling;
-
-		console.debug("  - adding new heading");
-
-        var newHeading = document.createElement('h3')
-        newHeading.id = 'bluefin-showreleasedeploymentprocess-heading';
-        newHeading.className = 'margin-top-20';
-        newHeading.innerText = "Deployment Process";
-		variablesNote.parentNode.insertBefore(newHeading, variablesNote.nextSibling.nextSibling.nextSibling);
-
-		console.debug("  - adding new desciption text and 'show' link");
-        var newDescription = document.createElement('p');
-        newDescription.id = 'bluefin-showreleasedeploymentprocess-description';
-        newDescription.className = 'subtle';
-        newDescription.innerText = 'When this release was created, a snapshot of the project deployment process was taken. '
-        var showLink = document.createElement('a');
-        showLink.innerText = 'Show »';
-        showLink.id = 'bluefin-showreleasedeploymentprocess-button'
-        showLink.style.cursor = 'pointer';
-		newDescription.appendChild(showLink);
-		variablesNote.parentNode.insertBefore(newDescription, newHeading.nextSibling);
-
-        console.debug("  - adding analytics handler");
-        var span = document.createElement('span');
-        span.id = 'bluefin-showreleasedeploymentprocess-analytics-handler';
-        span.onclick = span.onClick = function () {
-            chrome.runtime.sendMessage({ name: 'view-deployment-release-process', properties: {} }); // Analytics
-        }
-        variablesNote.parentNode.appendChild(span);
-
-		console.debug("  - getting template html 'show-release-deployment-plan.html'");
-		sendMessageHandler = sendMessageHandler || chrome.runtime.sendMessage;
-		receiveMessageHandler = receiveMessageHandler || receiveMessage;
-		sendMessageHandler({ message: 'get-template', properties: { templateName: 'show-release-deployment-plan.html' }}, receiveMessageHandler);
-    }
-
-	//separate function for mocking
-    function getPageLocationHash() {
-    	return location.hash;
-    }
-
-    function checkIfWeAreOnReleasePage(handler, getPageLocationHashfn) {
-    	getPageLocationHashfn = getPageLocationHashfn || getPageLocationHash;
-    	hash = getPageLocationHashfn();
-        if (hash.match(/#\/projects\/.*\/releases\/[^\/]*$/i)) {
-        	//cant use string.prototype.endsWith, as its not available under jasmine
-        	//would be nice to fold into the regex above
-        	if (hash.indexOf('/create', hash.length - '/create'.length) == -1) { 
-	        	handler = handler || addDeploymentProcessLink
-	        	handler();
-			}
-    	}
-    }
-
-    function setOctopusVersion(octopusVersion) {
-        pygmy3_0.viewReleaseDeploymentProcess.octopusVersion = octopusVersion;
-    }
-
-    function observe(content, octopusVersion) {
-    	setOctopusVersion(octopusVersion);
-		var observer = new MutationObserver(function(targets, observer) { checkIfWeAreOnReleasePage(); });
-        observer.observe(content, { childList: true, subtree: true, attributes: false, characterData: false});
-
-        chrome.runtime.onMessage.addListener(receiveMessage);
-    }
-
-    return {
-        observe: observe,
-        receiveMessage: receiveMessage,
-        checkIfWeAreOnReleasePage: checkIfWeAreOnReleasePage,
-        addDeploymentProcessLink: addDeploymentProcessLink,
-        setOctopusVersion: setOctopusVersion
+                        $scope.project = project;
+                        $scope.lifecycle = lifecycle;
+                        $scope.environments = environments;
+                        $scope.wasDeployedToChannel = wasDeployedToChannel;
+                        $scope.channelName = wasDeployedToChannel ? _.filter(channels.Items, function(c) {
+                          return c.Id == release.ChannelId;
+                        })[0].Name : null;
+                        $scope.channels = channels;
+                        $scope.deploymentProcess = deploymentProcess;
+                        $scope.builtInFeedPackageActions = _.filter(_.flatten(_.map(deploymentProcess.Steps, getActionFromStep)), isBuiltInFeedAction);
+                        _.each(deploymentProcess.Steps, function(s) {
+                          _.each(s.Actions, function(a) {
+                            a.channelMatches = channelMatches(release, a);
+                            a.environments = getTags(a.Environments, environments);
+                            if (a.channels) {
+                              a.channels = getTags(a.Channels, channels.Items);
+                            }
+                          });
+                          s.channelMatches = _.any(s.Actions, function(a) {
+                            return a.channelMatches;
+                          });
+                        });
+                        return;
+                      }));
+                    }));
+                  }));
+                }));
+              }));
+            }));
+          }));
+        },
+        dialogClass: 'modal',
+      });
     };
+  }
+
+  function addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler) {
+    if (document.getElementById('bluefin-showreleasedeploymentprocess-button')) {
+      return;
+    }
+
+    console.log('Loading Bluefin feature \'show release deployment process\'');
+
+    var headings = document.querySelectorAll('h3');
+    var variablesHeading;
+    for (var i = 0; i < headings.length; i++) {
+      if (headings[i].innerText === 'Variables') {
+        variablesHeading = headings[i];
+      }
+    }
+    var variablesNote = variablesHeading.nextSibling.nextSibling;
+
+    console.debug('  - adding new heading');
+
+    var newHeading = document.createElement('h3');
+    newHeading.id = 'bluefin-showreleasedeploymentprocess-heading';
+    newHeading.className = 'margin-top-20';
+    newHeading.innerText = 'Deployment Process';
+    variablesNote.parentNode.insertBefore(newHeading, variablesNote.nextSibling.nextSibling.nextSibling);
+
+    console.debug('  - adding new desciption text and \'show\' link');
+    var newDescription = document.createElement('p');
+    newDescription.id = 'bluefin-showreleasedeploymentprocess-description';
+    newDescription.className = 'subtle';
+    newDescription.innerText = 'When this release was created, a snapshot of the project deployment process was taken. ';
+    var showLink = document.createElement('a');
+    showLink.innerText = 'Show »';
+    showLink.id = 'bluefin-showreleasedeploymentprocess-button';
+    showLink.style.cursor = 'pointer';
+    newDescription.appendChild(showLink);
+    variablesNote.parentNode.insertBefore(newDescription, newHeading.nextSibling);
+
+    console.debug('  - adding analytics handler');
+    var span = document.createElement('span');
+    span.id = 'bluefin-showreleasedeploymentprocess-analytics-handler';
+    span.onclick = span.onClick = function() {
+      chrome.runtime.sendMessage({name: 'view-deployment-release-process', properties: {}}); // Analytics
+    };
+    variablesNote.parentNode.appendChild(span);
+
+    console.debug('  - getting template html \'show-release-deployment-plan.html\'');
+    sendMessageHandler = sendMessageHandler || chrome.runtime.sendMessage;
+    receiveMessageHandler = receiveMessageHandler || receiveMessage;
+    sendMessageHandler({message: 'get-template', properties: {templateName: 'show-release-deployment-plan.html'}}, receiveMessageHandler);
+  }
+
+  // separate function for mocking
+  function getPageLocationHash() {
+    return location.hash;
+  }
+
+  function checkIfWeAreOnReleasePage(handler, getPageLocationHashfn) {
+    getPageLocationHashfn = getPageLocationHashfn || getPageLocationHash;
+    hash = getPageLocationHashfn();
+    if (hash.match(/#\/projects\/.*\/releases\/[^\/]*$/i)) {
+      // cant use string.prototype.endsWith, as its not available under jasmine
+      // would be nice to fold into the regex above
+      if (hash.indexOf('/create', hash.length - '/create'.length) == -1) {
+        handler = handler || addDeploymentProcessLink;
+        handler();
+      }
+    }
+  }
+
+  function setOctopusVersion(octopusVersion) {
+    pygmy3_0.viewReleaseDeploymentProcess.octopusVersion = octopusVersion;
+  }
+
+  function observe(content, octopusVersion) {
+    setOctopusVersion(octopusVersion);
+    var observer = new MutationObserver(function(targets, observer) {
+      checkIfWeAreOnReleasePage();
+    });
+    observer.observe(content, {childList: true, subtree: true, attributes: false, characterData: false});
+
+    chrome.runtime.onMessage.addListener(receiveMessage);
+  }
+
+  return {
+    observe: observe,
+    receiveMessage: receiveMessage,
+    checkIfWeAreOnReleasePage: checkIfWeAreOnReleasePage,
+    addDeploymentProcessLink: addDeploymentProcessLink,
+    setOctopusVersion: setOctopusVersion,
+  };
 })();

--- a/src/3.0/view-release-deployment-process.js
+++ b/src/3.0/view-release-deployment-process.js
@@ -42,11 +42,11 @@ pygmy3_0.viewReleaseDeploymentProcess = (function() {
           };
           $scope.actionClass = function(action) {
             return action.ActionType.replace('.', '').toLowerCase();
-          },
-            $scope.canHaveChildren = function(step) {
-              var action = pluginRegistry.getDeploymentAction(step.Actions[0].ActionType);
-              return action.canHaveChildren;
-            };
+          };
+          $scope.canHaveChildren = function(step) {
+            var action = pluginRegistry.getDeploymentAction(step.Actions[0].ActionType);
+            return action.canHaveChildren;
+          };
 
           $scope.releaseVersion = $routeParams.version;
           var projectId = $routeParams.id || $routeParams.projectId;
@@ -56,7 +56,7 @@ pygmy3_0.viewReleaseDeploymentProcess = (function() {
               return '';
             }
             var result = [];
-            return _.each(selectedOptions, function(e) {
+            return selectedOptions.forEach(function(e) {
               allOptions.indexOf(e.Id) >= 0 && result.push(e.Name);
             }),
               result.join(',');
@@ -76,7 +76,7 @@ pygmy3_0.viewReleaseDeploymentProcess = (function() {
             if (action.Channels.length == 0) {
               return true;
             }
-            return _.indexOf(action.Channels, release.ChannelId) > -1;
+            return action.Channels.indexOf(release.ChannelId) > -1;
           }
 
           isLoading.promise(octopusRepository.Projects.get(projectId).then(function(project) {
@@ -98,23 +98,25 @@ pygmy3_0.viewReleaseDeploymentProcess = (function() {
                         $scope.lifecycle = lifecycle;
                         $scope.environments = environments;
                         $scope.wasDeployedToChannel = wasDeployedToChannel;
-                        $scope.channelName = wasDeployedToChannel ? _.filter(channels.Items, function(c) {
+                        $scope.channelName = wasDeployedToChannel ? channels.Items.filter(function(c) {
                           return c.Id == release.ChannelId;
                         })[0].Name : null;
                         $scope.channels = channels;
                         $scope.deploymentProcess = deploymentProcess;
-                        $scope.builtInFeedPackageActions = _.filter(_.flatten(_.map(deploymentProcess.Steps, getActionFromStep)), isBuiltInFeedAction);
-                        _.each(deploymentProcess.Steps, function(s) {
-                          _.each(s.Actions, function(a) {
+                        var mapOfStepsToActions = deploymentProcess.Steps.map(getActionFromStep);
+                        var flattenedMapOfStepsToActions = [].concat.apply([], mapOfStepsToActions);
+                        $scope.builtInFeedPackageActions = flattenedMapOfStepsToActions.filter(isBuiltInFeedAction);
+                        deploymentProcess.Steps.forEach(function(s) {
+                          s.Actions.forEach(function(a) {
                             a.channelMatches = channelMatches(release, a);
                             a.environments = getTags(a.Environments, environments);
                             if (a.channels) {
                               a.channels = getTags(a.Channels, channels.Items);
                             }
                           });
-                          s.channelMatches = _.any(s.Actions, function(a) {
+                          s.channelMatches = s.Actions.filter(function(a) {
                             return a.channelMatches;
-                          });
+                          }).length > 0;
                         });
                         return;
                       }));

--- a/src/templates/show-release-deployment-plan.html
+++ b/src/templates/show-release-deployment-plan.html
@@ -6,6 +6,7 @@
 <div class="modal-body">
 	<style>#viewReleaseDeploymentProcessContainer a { color: #333; } .col-lg-8 { width: 100%;}</style>
 	<div id="viewReleaseDeploymentProcessContainer" >
+		<loading-wrapper busy="isLoading">
 		<project-layout suppress-create-release="deploymentProcess.Steps.length < 1">
 			<div class="row">
 				<div class="col-sm-8 col-md-8 col-lg-8">


### PR DESCRIPTION
For some reason, underscorejs was no longer in scope. This rewrites a bunch of it to no longer use underscorejs.

It also adds eslint stuff, so that I could have a bit more confidence I wasn't breaking stuff. Not sure if you want to include that - let me know if you don't and I'll remove it.

Tested against:

* 3.3.0
* 3.9.0
* 3.13.0
* 3.16.1-ci0023

Fixes #95